### PR TITLE
Fixes #2. Apply sorts before truncating list view.

### DIFF
--- a/src/plugins/sortingview/gui/extensions/unitstable/Units/Units.tsx
+++ b/src/plugins/sortingview/gui/extensions/unitstable/Units/Units.tsx
@@ -5,9 +5,9 @@ import useChannel from 'figurl/kachery-react/useChannel';
 import useKacheryNode from 'figurl/kachery-react/useKacheryNode';
 import { usePlugins } from 'figurl/labbox-react';
 import sortByPriority from 'figurl/labbox-react/extensionSystem/sortByPriority';
-import { SortingComparisonUnitMetricPlugin } from '../../../pluginInterface/SortingComparisonUnitMetricPlugin';
 import React, { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import { LabboxPlugin, Recording, sortingComparisonUnitMetricPlugins, SortingUnitMetricPlugin, sortingUnitMetricPlugins, SortingViewProps } from "../../../pluginInterface";
+import { SortingComparisonUnitMetricPlugin } from '../../../pluginInterface/SortingComparisonUnitMetricPlugin';
 import UnitsTable from './UnitsTable';
 
 // const defaultLabelOptions = ['noise', 'MUA', 'artifact', 'accept', 'reject'];
@@ -157,13 +157,11 @@ const Units: React.FunctionComponent<SortingViewProps & OwnProps> = (props) => {
     const metricsPlugins = useMemo(() => (sortingUnitMetricPlugins(plugins)), [plugins])
     const comparisonMetricsPlugins = useMemo(() => (sortingComparisonUnitMetricPlugins(plugins)), [plugins])
 
-    let units = selection.visibleUnitIds || sortingInfo.unit_ids
-    let showExpandButton = false;
+    const units = selection.visibleUnitIds || sortingInfo.unit_ids
     const totalNumUnits = units.length
-    if ((!expandedTable) && (totalNumUnits > 30)) {
-        units = units.slice(0, 30);
-        showExpandButton = true;
-    }
+    const maxDisplayedUnits = 30
+    const showExpandButton = !expandedTable && (totalNumUnits > maxDisplayedUnits)
+    const displayedUnitCount = showExpandButton ? maxDisplayedUnits : totalNumUnits
 
     const selectedUnitIds = useMemo(() => selection.selectedUnitIds || [], [selection.selectedUnitIds])
     const unitMetricsUri = useMemo(() => (sorting.unitMetricsUri), [sorting.unitMetricsUri])
@@ -175,6 +173,7 @@ const Units: React.FunctionComponent<SortingViewProps & OwnProps> = (props) => {
                     sortingUnitMetrics={metricsPlugins}
                     sortingComparisonUnitMetrics={comparisonMetricsPlugins}
                     units={units}
+                    displayedUnitCount={displayedUnitCount}
                     metrics={metrics}
                     selectedUnitIds={selectedUnitIds}
                     selectionDispatch={selectionDispatch}

--- a/src/plugins/sortingview/gui/extensions/unitstable/Units/UnitsTable.tsx
+++ b/src/plugins/sortingview/gui/extensions/unitstable/Units/UnitsTable.tsx
@@ -1,17 +1,18 @@
 import { useChannel, usePureCalculationTask } from 'figurl/kachery-react';
 import sortByPriority from 'figurl/labbox-react/extensionSystem/sortByPriority';
-import { ExternalSortingUnitMetric } from '../../../pluginInterface/Sorting';
-import { SortingComparisonUnitMetricPlugin } from '../../../pluginInterface/SortingComparisonUnitMetricPlugin';
+import sortingviewTaskFunctionIds from 'plugins/sortingview/sortingviewTaskFunctionIds';
 import React, { FunctionComponent, useCallback, useMemo } from 'react';
 import { mergeGroupForUnitId, Sorting, SortingCuration, SortingSelectionDispatch, SortingUnitMetricPlugin } from "../../../pluginInterface";
+import { ExternalSortingUnitMetric } from '../../../pluginInterface/Sorting';
+import { SortingComparisonUnitMetricPlugin } from '../../../pluginInterface/SortingComparisonUnitMetricPlugin';
 import '../unitstable.css';
 import TableWidget, { Column, Row } from './TableWidget';
-import sortingviewTaskFunctionIds from 'plugins/sortingview/sortingviewTaskFunctionIds';
 
 interface Props {
     sortingUnitMetrics?: SortingUnitMetricPlugin[]
     sortingComparisonUnitMetrics?: SortingComparisonUnitMetricPlugin[]
     units: number[]
+    displayedUnitCount?: number
     metrics?: {[key: string]: {data: {[key: string]: any}, error: string | null}}
     selectedUnitIds?: number[]
     selectionDispatch: SortingSelectionDispatch
@@ -87,7 +88,7 @@ const getLabelsForUnitId = (unitId: number, curation: SortingCuration) => {
 
 
 const UnitsTable: FunctionComponent<Props> = (props) => {
-    const { unitMetricsUri, sortingUnitMetrics, sortingComparisonUnitMetrics, units, metrics, selectedUnitIds, selectionDispatch, curation, height, selectionDisabled, sortingSelector } = props
+    const { unitMetricsUri, sortingUnitMetrics, sortingComparisonUnitMetrics, units, displayedUnitCount, metrics, selectedUnitIds, selectionDispatch, curation, height, selectionDisabled, sortingSelector } = props
     const selectedRowIds = useMemo(() => (selectedUnitIds || []).map(unitId => (unitId + '')), [selectedUnitIds])
     const _metrics = useMemo(() => metrics || {}, [metrics])
 
@@ -220,6 +221,7 @@ const UnitsTable: FunctionComponent<Props> = (props) => {
             columns={columns}
             selectedRowIds={selectedRowIds}
             onSelectedRowIdsChanged={handleSelectedRowIdsChanged}
+            displayedRowCount={displayedUnitCount}
             defaultSortColumnName="_unit_id"
             height={height}
             selectionDisabled={selectionDisabled}


### PR DESCRIPTION
Fixes figurl issue #2.

This PR makes a few seemingly-minor changes to the `Units`, `UnitsTable`, and `TableWidget` components. However, these changes may have some performance implications, so we should probably think about them and profile with non-trivial data before acceptance.

### Background:

In the current system, the `Units` plugin provides the start of the units table display chain. This component interfaces directly with the plugin infrastructure, selects the units to be displayed and the metrics to be provided, and mediates selection state (passing through references to the `selection` object and the `selectionDispatch` callback that can modify its state).

The `UnitsTable` component converts unit list information into a more-tabular format (and is what is used, via the `SelectUnitsWidget`, in other plugins that have integrated unit selection). `UnitsTable`'s responsibilities are to collect all data for tabular display by the `TableWidget`. The `UnitsTable` takes a list of units and the internal and external metrics which form the body of the table, fetches the column headers (from the metrics), and builds the rows by firing off internal hither Jobs and external figurl Tasks to fetch data for each unit. It builds out the matrix of values and passes this matrix into the `TableWidget` for display.

The `TableWidget` component is somewhat more general-purpose. Its responsibilities are (1) rendering individual rows, including applying selection status; (2) providing infrastructure for modifying selection status (via checkboxes and a header-row select-all checkbox), which all work using callbacks to a cross-plugin-level state; and (3) providing sort functionality by tracking user clicks on column headers, rationalizing sorting, and applying sorting to the rows of the matrix it received.

### Present Change:

In the current (main-branch) design, construction of the units table has contributions from all three modules. The **Units** component identifies the rows to be displayed; the **UnitsTable** component fetches their data; and the **TableWidget** applies sorting. I have not attempted to evaluate or address this division of responsibilities. Regardless of that structure, the issue remains: because sorting happens at a lower level than unit inclusion, only the included units can be sorted. To fix this, we have to fetch data for all units prior to limiting the displayed set. The performance implication is that this means for displaying any number of units, we will now need to fetch the data for all units in the set, regardless of whether they are visible.

That's the solution implemented by the changes proposed in this PR: instead of truncating the units list sent down from the `Units` component, I now send the entire set of units from the sorting, along with a value for the maximum number to display. As a result, the downstream components will fetch all metric data, and sort on the entire set of metric data, before filtering the displayed rows.

I don't expect the performance hit will be too bad, actually, because we are able to memoize the fully populated matrix of units and metric values; apart from a slower initial load of the Units Table view, users probably won't notice anything. However, I haven't been able to test this on a full-size data set (still getting that set up).

Note that this PR also fixes the issue from #2 where having more units selected than displayed would result in the select-all button not thinking everything was selected. However, we *can* now have a different issue where we select all in a truncated list, then re-sort; the button thinks 'all' are selected because the old selected elements persist, and the number of selected elements matches the number of displayed elements; however, some of the selected elements are invisible and some elements that are displayed are not selected. Dunno if this is worth further tweaking, even if it's kind of an odd UI experience.