### PR TITLE
Add 'Show all units' and ensure unit list expansion is on a new line.

### DIFF
--- a/src/figurl/labbox-react/HomePage/localStyles.css
+++ b/src/figurl/labbox-react/HomePage/localStyles.css
@@ -41,8 +41,12 @@
     min-width: 206px;
 } */
 
+.plotWrapperButtonParent {
+    display: inline-block
+}
+
 .plotWrapperStyleButton {
-    padding-top: 100px;
+    padding-top: 50px;
 }
 
 .plotUnselectedStyle {

--- a/src/plugins/sortingview/gui/commonComponents/SortingUnitPlotGrid/SortingUnitPlotGrid.tsx
+++ b/src/plugins/sortingview/gui/commonComponents/SortingUnitPlotGrid/SortingUnitPlotGrid.tsx
@@ -1,5 +1,5 @@
 import { Button, Grid } from '@material-ui/core';
-import React, { FunctionComponent, useCallback, useMemo, useState } from 'react';
+import React, { Fragment, FunctionComponent, useCallback, useMemo, useState } from 'react';
 import { isMergeGroupRepresentative, Sorting, SortingCuration, SortingInfo, SortingSelection, SortingSelectionDispatch } from "../../pluginInterface";
 import { useSortingInfo } from '../../pluginInterface/useSortingInfo';
 
@@ -13,8 +13,8 @@ type Props = {
 }
 
 const SortingUnitPlotGrid: FunctionComponent<Props> = ({ sorting, selection, curation, selectionDispatch, unitComponent, sortingSelector }) => {
-    const maxUnitsVisibleIncrement = 60;
-    const [maxUnitsVisible, setMaxUnitsVisible] = useState(30);
+    const maxUnitsVisibleIncrement = 3
+    const [maxUnitsVisible, setMaxUnitsVisible] = useState(3)
     const sortingInfo: SortingInfo | undefined = useSortingInfo(sorting.sortingPath)
 
     const visibleUnitIds = useMemo(() => selection.visibleUnitIds, [selection.visibleUnitIds])
@@ -34,50 +34,53 @@ const SortingUnitPlotGrid: FunctionComponent<Props> = ({ sorting, selection, cur
     }, [selectionDispatch])
 
     return (
-        <Grid container>
-            {
-                unit_ids.map(unitId => (
-                    <Grid key={unitId} item>
-                        <div className='plotWrapperStyle'
-                        >
-                            <div
-                                data-unit-id={unitId}
-                                className={selectedUnitIds?.includes(unitId) ? 'plotSelectedStyle' : 'plotUnselectedStyle'}
-                                onClick={handleUnitClick}
+        <Fragment>
+            <Grid container>
+                {
+                    unit_ids.map(unitId => (
+                        <Grid key={unitId} item>
+                            <div className='plotWrapperStyle'
                             >
-                                <div className='plotUnitLabel'>
-                                    <div>Unit {unitId}{sortingSelector || ''}</div>
+                                <div
+                                    data-unit-id={unitId}
+                                    className={selectedUnitIds?.includes(unitId) ? 'plotSelectedStyle' : 'plotUnselectedStyle'}
+                                    onClick={handleUnitClick}
+                                >
+                                    <div className='plotUnitLabel'>
+                                        <div>Unit {unitId}{sortingSelector || ''}</div>
+                                    </div>
+                                    {
+                                        unitComponent(unitId)
+                                    }
+                                    {/* <ClientSidePlot
+                                        dataFunctionName={dataFunctionName}
+                                        dataFunctionArgs={dataFunctionArgsCallback(unitId)}
+                                        boxSize={boxSize}
+                                        PlotComponent={plotComponent}
+                                        plotComponentArgs={plotComponentArgsCallback(unitId)}
+                                        plotComponentProps={plotComponentPropsCallback ? plotComponentPropsCallback(unitId): undefined}
+                                        calculationPool={calculationPool}
+                                        title=""
+                                        hither={hither}
+                                    /> */}
                                 </div>
-                                {
-                                    unitComponent(unitId)
-                                }
-                                {/* <ClientSidePlot
-                                    dataFunctionName={dataFunctionName}
-                                    dataFunctionArgs={dataFunctionArgsCallback(unitId)}
-                                    boxSize={boxSize}
-                                    PlotComponent={plotComponent}
-                                    plotComponentArgs={plotComponentArgsCallback(unitId)}
-                                    plotComponentProps={plotComponentPropsCallback ? plotComponentPropsCallback(unitId): undefined}
-                                    calculationPool={calculationPool}
-                                    title=""
-                                    hither={hither}
-                                /> */}
                             </div>
-                        </div>
-                    </Grid>
-                ))
-            }
+                        </Grid>
+                    ))
+                }
+            </Grid>
             {
                 showExpandButton && (
-                    <div className='plotWrapperStyle'>
+                    <div className='plotWrapperButtonParent'>
                         <div className='plotWrapperStyleButton'>
                             <Button onClick={() => {setMaxUnitsVisible(maxUnitsVisible + maxUnitsVisibleIncrement)}}>Show more units</Button>
+                            <Button onClick={() => {setMaxUnitsVisible(baseUnitIds.length)}}>Show all units</Button>
                         </div>
                     </div>
                     
                 )
             }
-        </Grid>
+        </Fragment>
     );
 }
 

--- a/src/plugins/sortingview/gui/commonComponents/SortingUnitPlotGrid/SortingUnitPlotGrid.tsx
+++ b/src/plugins/sortingview/gui/commonComponents/SortingUnitPlotGrid/SortingUnitPlotGrid.tsx
@@ -13,8 +13,8 @@ type Props = {
 }
 
 const SortingUnitPlotGrid: FunctionComponent<Props> = ({ sorting, selection, curation, selectionDispatch, unitComponent, sortingSelector }) => {
-    const maxUnitsVisibleIncrement = 3
-    const [maxUnitsVisible, setMaxUnitsVisible] = useState(3)
+    const maxUnitsVisibleIncrement = 60
+    const [maxUnitsVisible, setMaxUnitsVisible] = useState(30)
     const sortingInfo: SortingInfo | undefined = useSortingInfo(sorting.sortingPath)
 
     const visibleUnitIds = useMemo(() => selection.visibleUnitIds, [selection.visibleUnitIds])


### PR DESCRIPTION
Fixes #5.

Looking at the implementation, the display of new elements is an integrated feature within the `SortingUnitPlotGrid` component that is intended to wrap any unit-by-unit visualization display.

The easiest fix is just to add an extra button to serve the 'Show all units' functionality. On click, this button sets the max units visible to the max units known to the view.

I also tweaked the CSS and exact structure of the plotgrid return so that the buttons to expand the units always appear on their own line--it seemed awkward for those to be sometimes displayed inline with the plots themselves.

Side note that the `plotWrapperStyle` class is referred to throughout both this component and the `SortingUnitPlotGridNumpy` component, but its definition is commented out, so it doesn't actually do anything.