### PR TITLE
Add electrode geometry toggle to avg waveform ctrl panel

### DIFF
--- a/src/plugins/sortingview/gui/extensions/averagewaveforms/AverageWaveformsView/AverageWaveformView.tsx
+++ b/src/plugins/sortingview/gui/extensions/averagewaveforms/AverageWaveformsView/AverageWaveformView.tsx
@@ -6,7 +6,7 @@ import sortingviewTaskFunctionIds from 'plugins/sortingview/sortingviewTaskFunct
 import React, { FunctionComponent, useMemo } from 'react'
 import { applyMergesToUnit, Recording, Sorting, SortingCuration, SortingSelectionDispatch } from '../../../pluginInterface'
 import { ElectrodeOpts } from '../../common/sharedCanvasLayers/electrodesLayer'
-import { ActionItem, DividerItem } from '../../common/Toolbars'
+import { AverageWaveformAction } from './AverageWaveformsView'
 import WaveformWidget, { defaultWaveformOpts } from './WaveformWidget'
 
 
@@ -26,7 +26,7 @@ type Props = {
     width: number
     height: number
     noiseLevel: number
-    customActions?: (ActionItem | DividerItem)[]
+    customActions?: AverageWaveformAction[]
     snippetLen?: [number, number]
     visibleElectrodeIds?: number[]
     selectedElectrodeIds?: number[]

--- a/src/plugins/sortingview/gui/extensions/averagewaveforms/AverageWaveformsView/AverageWaveformsView.tsx
+++ b/src/plugins/sortingview/gui/extensions/averagewaveforms/AverageWaveformsView/AverageWaveformsView.tsx
@@ -9,12 +9,12 @@ import { FaArrowDown, FaArrowUp } from 'react-icons/fa'
 import SortingUnitPlotGrid from '../../../commonComponents/SortingUnitPlotGrid/SortingUnitPlotGrid'
 import info from '../../../helpPages/AverageWaveforms.md.gen'
 import { SortingViewProps } from '../../../pluginInterface'
-import { ActionItem, DividerItem } from '../../common/Toolbars'
+import { ActionItem, CheckboxItem, DividerItem } from '../../common/Toolbars'
 import ViewToolbar from '../../common/ViewToolbar'
 import AverageWaveformView from './AverageWaveformView'
 
 
-export type AverageWaveformAction = ActionItem  | DividerItem
+export type AverageWaveformAction = ActionItem  | DividerItem | CheckboxItem
 
 const TOOLBAR_INITIAL_WIDTH = 36 // hard-coded for now
 
@@ -49,6 +49,10 @@ const AverageWaveformsView: FunctionComponent<SortingViewProps> = (props) => {
             />
     ), [sorting, recording, selectionDispatch, noiseLevel, scalingActions, curation, snippetLen, visibleElectrodeIds, selectedElectrodeIds, ampScaleFactor, applyMerges, waveformsMode])
 
+    const _handleWaveformToggle = useCallback(() => {
+        selectionDispatch({type: 'ToggleWaveformsMode', waveformsMode: waveformsMode})
+    }, [selectionDispatch, waveformsMode])
+
     const _handleScaleAmplitudeUp = useCallback(() => {
         selectionDispatch({type: 'ScaleAmpScaleFactor', direction: 'up'})
     }, [selectionDispatch])
@@ -71,10 +75,19 @@ const AverageWaveformsView: FunctionComponent<SortingViewProps> = (props) => {
                 title: 'Scale amplitude down [down arrow]',
                 icon: <FaArrowDown />,
                 keyCode: 40
+            },
+            {
+                type: 'divider'
+            },
+            {
+                type: 'checkbox',
+                callback: _handleWaveformToggle,
+                title: waveformsMode === 'geom' ? 'Hide electrode geometry' : 'Show electrode geometry',
+                selected: waveformsMode === 'geom'
             }
         ]
         setScalingActions(actions)
-    }, [_handleScaleAmplitudeUp, _handleScaleAmplitudeDown])
+    }, [_handleScaleAmplitudeUp, _handleScaleAmplitudeDown, _handleWaveformToggle, waveformsMode])
 
     const infoVisible = useVisible()
 

--- a/src/plugins/sortingview/gui/extensions/common/Toolbars.ts
+++ b/src/plugins/sortingview/gui/extensions/common/Toolbars.ts
@@ -12,3 +12,12 @@ export interface ActionItem {
 export interface DividerItem {
     type: 'divider'
 }
+
+export interface CheckboxItem {
+    type: 'checkbox'
+    callback: () => void
+    title: string
+    selected?: boolean
+    keyCode?: number
+    disabled?: boolean
+}

--- a/src/plugins/sortingview/gui/extensions/common/ViewToolbar.tsx
+++ b/src/plugins/sortingview/gui/extensions/common/ViewToolbar.tsx
@@ -1,4 +1,4 @@
-import { IconButton } from '@material-ui/core';
+import { Checkbox, IconButton } from '@material-ui/core';
 import React, { FunctionComponent, useMemo } from 'react';
 
 interface Props {
@@ -16,6 +16,7 @@ type Button = {
     icon: any
     selected: boolean
     disabled?: boolean
+    // TODO: Support for indeterminate state for checkboxes?
 }
 
 const ViewToolbar: FunctionComponent<Props> = (props) => {
@@ -31,7 +32,7 @@ const ViewToolbar: FunctionComponent<Props> = (props) => {
                 type: a.type || 'button',
                 title: a.title,
                 onClick: a.callback,
-                icon: a.icon,
+                icon: a.icon || '',
                 selected: a.selected,
                 disabled: a.disabled
             });
@@ -50,6 +51,17 @@ const ViewToolbar: FunctionComponent<Props> = (props) => {
                                 {button.icon}
                             </IconButton>
                         );
+                    }
+                    else if (button.type === 'checkbox') {
+                        return (
+                            <Checkbox
+                                checked={button.selected}
+                                onClick={button.onClick}
+                                style={{padding: 1, paddingLeft: 6 }}
+                                title={button.title}
+                                disabled={button.disabled}
+                            />
+                        )
                     }
                     else if (button.type === 'divider') {
                         return <hr key={ii} />;

--- a/src/plugins/sortingview/gui/extensions/common/sharedCanvasLayers/electrodesLayer.ts
+++ b/src/plugins/sortingview/gui/extensions/common/sharedCanvasLayers/electrodesLayer.ts
@@ -2,7 +2,7 @@ import { CanvasPainter } from "figurl/labbox-react/components/CanvasWidget/Canva
 import { CanvasDragEvent, CanvasWidgetLayer, ClickEvent, ClickEventType, DiscreteMouseEventHandler, DragHandler } from "figurl/labbox-react/components/CanvasWidget/CanvasWidgetLayer";
 import { pointIsInEllipse, RectangularRegion, rectangularRegionsIntersect } from "figurl/labbox-react/components/CanvasWidget/Geometry";
 import { RecordingSelectionDispatch } from '../../../pluginInterface';
-import { ActionItem, DividerItem } from "../Toolbars";
+import { ActionItem, CheckboxItem, DividerItem } from "../Toolbars";
 import setupElectrodes, { ElectrodeBox } from './setupElectrodes';
 
 export type Electrode = {
@@ -34,7 +34,7 @@ export type ElectrodeLayerProps = {
     selectedElectrodeIds: number[]
     selectionDispatch: RecordingSelectionDispatch
     electrodeOpts: ElectrodeOpts
-    customActions?: (ActionItem | DividerItem)[]
+    customActions?: (ActionItem | CheckboxItem | DividerItem )[]
 }
 
 type LayerState = {

--- a/src/plugins/sortingview/gui/extensions/mountainview/MVSortingView/OptionsControl.tsx
+++ b/src/plugins/sortingview/gui/extensions/mountainview/MVSortingView/OptionsControl.tsx
@@ -20,7 +20,7 @@ const WaveformLayoutControl: FunctionComponent<{selection: SortingSelection, sel
     const checked = waveformsMode === 'geom'
 
     const handleToggle = useCallback(() => {
-        selectionDispatch({type: 'SetWaveformsMode', waveformsMode: waveformsMode === 'geom' ? 'vertical' : 'geom'})
+        selectionDispatch({type: 'ToggleWaveformsMode', waveformsMode: waveformsMode })
     }, [waveformsMode, selectionDispatch])
 
     return (

--- a/src/plugins/sortingview/gui/pluginInterface/RecordingSelection.ts
+++ b/src/plugins/sortingview/gui/pluginInterface/RecordingSelection.ts
@@ -115,6 +115,11 @@ type SetWaveformsModeRecordingSelectionAction = {
     waveformsMode: 'geom' | 'vertical'
 }
 
+type ToggleWaveformsModeRecordingSelectionAction = {
+    type: 'ToggleWaveformsMode',
+    waveformsMode: WaveformsMode
+}
+
 type SetRecordingSelectionAction = {
     type: 'Set',
     state: RecordingSelection
@@ -125,7 +130,7 @@ type TimeShiftFrac = {
     frac: number
 }
 
-export type RecordingSelectionAction = SetRecordingSelectionRecordingSelectionAction | SetSelectedElectrodeIdsRecordingSelectionAction | SetVisibleElectrodeIdsRecordingSelectionAction | SetNumTimepointsRecordingSelectionAction | SetCurrentTimepointRecordingSelectionAction | SetTimeRangeRecordingSelectionAction | ZoomTimeRangeRecordingSelectionAction | SetAmpScaleFactorRecordingSelectionAction | ScaleAmpScaleFactorRecordingSelectionAction | SetCurrentTimepointVelocityRecordingSelectionAction | SetWaveformsModeRecordingSelectionAction | SetRecordingSelectionAction | TimeShiftFrac
+export type RecordingSelectionAction = SetRecordingSelectionRecordingSelectionAction | SetSelectedElectrodeIdsRecordingSelectionAction | SetVisibleElectrodeIdsRecordingSelectionAction | SetNumTimepointsRecordingSelectionAction | SetCurrentTimepointRecordingSelectionAction | SetTimeRangeRecordingSelectionAction | ZoomTimeRangeRecordingSelectionAction | SetAmpScaleFactorRecordingSelectionAction | ScaleAmpScaleFactorRecordingSelectionAction | SetCurrentTimepointVelocityRecordingSelectionAction | SetWaveformsModeRecordingSelectionAction | SetRecordingSelectionAction | TimeShiftFrac | ToggleWaveformsModeRecordingSelectionAction
 
 const adjustTimeRangeToIncludeTimepoint = (timeRange: {min: number, max: number}, timepoint: number) => {
     if ((timeRange.min <= timepoint) && (timepoint < timeRange.max)) return timeRange
@@ -222,6 +227,12 @@ export const recordingSelectionReducer: Reducer<RecordingSelection, RecordingSel
         return {
             ...state,
             waveformsMode: action.waveformsMode
+        }
+    }
+    else if (action.type === 'ToggleWaveformsMode') {
+        return {
+            ...state,
+            waveformsMode: action.waveformsMode === 'geom' ? 'vertical' : 'geom'
         }
     }
     else if (action.type === 'TimeShiftFrac') {


### PR DESCRIPTION
Fixes issue #7.

This turned out to be a little more involved than I'd first thought. It comprises two areas of change:

- For the "use electrode geometry" toggle, this is currently stored as the `waveformsMode` member on the `RecordingSelection` object in the [pluginInterface](https://github.com/magland/figurl/tree/main/src/plugins/sortingview/gui/pluginInterface) with the UI implemented in the `OptionsControl` widget in [MountainView](https://github.com/magland/figurl/tree/main/src/plugins/sortingview/gui/extensions/mountainview/MVSortingView). Prior to this change, the logic for the toggle was in a callback in the latter widget. In order to avoid repeating the code, I bumped that logic out to the dispatch handler itself back in `RecordingSelection`, with a "toggle" action type instead of just having the callback set the value directly. I think this will reduce the chance of writing improper values, & centralizes what needs to be changed if we were to add more states than just the two.
- The current control panel framework for plugins doesn't support checkboxes (or, really, buttons that display state, unless I want to do something kinda hacky). I wound up implementing a new type of control item in the `Toolbars` and corresponding rendering logic on `ViewToolbars` in the [common extensions folder](https://github.com/magland/figurl/tree/main/src/plugins/sortingview/gui/extensions/common). I do expect this will grow some more, too, when I implement a zoom level display and reset-zoom button (issue to come).

Before submitting the PR, I confirmed that display looks good on my system for average waveforms and that the two options toggle in sync. I also checked the Timeseries and Cluster widgets to make sure that their control panels hadn't been affected by the changes I made to `ViewToolbar` etc, but this wasn't exhaustive--I could've missed something.

Still missing a big test set for performance, but I don't expect much performance impact from these changes: it didn't involve any new data elements into the views.