### PR TITLE
Convert SpikeAmplitudesView to use LockableSelectUnitsWidget.

### DIFF
--- a/src/plugins/sortingview/gui/extensions/correlograms/CrossCorrelogramsView/CrossCorrelogramsView.tsx
+++ b/src/plugins/sortingview/gui/extensions/correlograms/CrossCorrelogramsView/CrossCorrelogramsView.tsx
@@ -1,9 +1,9 @@
-import Splitter from 'figurl/labbox-react/components/Splitter/Splitter';
-import useLocalUnitIds from 'plugins/sortingview/gui/pluginInterface/useLocalUnitIds';
-import React, { FunctionComponent, useState } from 'react';
-import LockableSelectUnitsWidget from '../../../commonComponents/SelectUnitsWidget/LockableSelectUnitsWidget';
-import { SortingViewProps } from "../../../pluginInterface";
-import CrossCorrelogramsWidget from './CrossCorrelogramsWidget';
+import Splitter from 'figurl/labbox-react/components/Splitter/Splitter'
+import useLocalUnitIds from 'plugins/sortingview/gui/pluginInterface/useLocalUnitIds'
+import React, { FunctionComponent, useState } from 'react'
+import LockableSelectUnitsWidget from '../../../commonComponents/SelectUnitsWidget/LockableSelectUnitsWidget'
+import { SortingViewProps } from "../../../pluginInterface"
+import CrossCorrelogramsWidget from './CrossCorrelogramsWidget'
 
 const CrossCorrelogramsView: FunctionComponent<SortingViewProps> = ({sorting, selection, curation, selectionDispatch, width, height, sortingSelector}) => {
     const [locked, setLocked] = useState(false)

--- a/src/plugins/sortingview/gui/extensions/spikeamplitudes/SpikeAmplitudesView/SpikeAmplitudesTimeWidget.tsx
+++ b/src/plugins/sortingview/gui/extensions/spikeamplitudes/SpikeAmplitudesView/SpikeAmplitudesTimeWidget.tsx
@@ -29,6 +29,15 @@ const SpikeAmplitudesTimeWidget: FunctionComponent<Props> = ({ spikeAmplitudesDa
 
     const [spikeAmplitudesPanels, setSpikeAmplitudesPanels] = useState<SpikeAmplitudesPanel[] | null>(null)
 
+    const nullSpikeAmplitudesPanel = useMemo(() => {
+        return new SpikeAmplitudesPanel({
+            spikeAmplitudesData: null,
+            recording,
+            sorting,
+            unitId: -1
+        })
+    }, [sorting, recording])
+
     useEffect(() => {
         const panels: SpikeAmplitudesPanel[] = []
         const allMins: number[] = []
@@ -46,12 +55,7 @@ const SpikeAmplitudesTimeWidget: FunctionComponent<Props> = ({ spikeAmplitudesDa
         })
         // we want the y-axis to show even when no units are selected
         if (panels.length === 0) {
-            panels.push(new SpikeAmplitudesPanel({
-                spikeAmplitudesData: null,
-                recording,
-                sorting,
-                unitId: -1
-            }))
+            panels.push(nullSpikeAmplitudesPanel)
         }
         if (allMins.length > 0) {
             panels.forEach(p => {
@@ -59,7 +63,7 @@ const SpikeAmplitudesTimeWidget: FunctionComponent<Props> = ({ spikeAmplitudesDa
             })
         }
         setSpikeAmplitudesPanels(panels)
-    }, [unitIds, sorting, curation, recording, spikeAmplitudesData, selection]) // important that this depends on selection so that we refresh when time range changes
+    }, [unitIds, sorting, curation, recording, spikeAmplitudesData, nullSpikeAmplitudesPanel, selection]) // important that this depends on selection so that we refresh when time range changes
 
     const panels = useMemo(() => (
         spikeAmplitudesPanels ? [combinePanels(spikeAmplitudesPanels, '')] : [] as SpikeAmplitudesPanel[]

--- a/src/plugins/sortingview/gui/extensions/spikeamplitudes/SpikeAmplitudesView/SpikeAmplitudesTimeWidget.tsx
+++ b/src/plugins/sortingview/gui/extensions/spikeamplitudes/SpikeAmplitudesView/SpikeAmplitudesTimeWidget.tsx
@@ -54,6 +54,7 @@ const SpikeAmplitudesTimeWidget: FunctionComponent<Props> = ({ spikeAmplitudesDa
             panels.push(p)
         })
         // we want the y-axis to show even when no units are selected
+        // NOTE: This doesn't actually seem to work right now...
         if (panels.length === 0) {
             panels.push(nullSpikeAmplitudesPanel)
         }

--- a/src/plugins/sortingview/gui/extensions/spikeamplitudes/SpikeAmplitudesView/SpikeAmplitudesView.tsx
+++ b/src/plugins/sortingview/gui/extensions/spikeamplitudes/SpikeAmplitudesView/SpikeAmplitudesView.tsx
@@ -1,34 +1,45 @@
 import Splitter from 'figurl/labbox-react/components/Splitter/Splitter'
-import SelectUnitsWidget from '../../../commonComponents/SelectUnitsWidget/SelectUnitsWidget'
+import useLocalUnitIds from 'plugins/sortingview/gui/pluginInterface/useLocalUnitIds'
+import React, { FunctionComponent, useState } from 'react'
+import LockableSelectUnitsWidget from '../../../commonComponents/SelectUnitsWidget/LockableSelectUnitsWidget'
 import { SortingViewProps } from '../../../pluginInterface'
-import React, { FunctionComponent } from 'react'
 import SpikeAmplitudesTimeWidget from './SpikeAmplitudesTimeWidget'
 import useSpikeAmplitudesData from './useSpikeAmplitudesData'
 
 const SpikeAmplitudesView: FunctionComponent<SortingViewProps> = ({recording, sorting, selection, selectionDispatch, curation, width, height, snippetLen, sortingSelector}) => {
+    const [locked, setLocked] = useState(false)
+    const [selectionLocal, selectionDispatchLocal] = useLocalUnitIds(selection, selectionDispatch, locked)
     const spikeAmplitudesData = useSpikeAmplitudesData(recording.recordingObject, sorting.sortingObject, snippetLen)
-    if (!spikeAmplitudesData) {
-        return <div>Creating spike amplitudes data...</div>
-    }
-    return (
-        <Splitter
-            width={width || 600}
-            height={height || 900} // how to determine default height?
-            initialPosition={200}
-        >
-            <SelectUnitsWidget sorting={sorting} selection={selection} selectionDispatch={selectionDispatch} curation={curation} sortingSelector={sortingSelector} />
-            <SpikeAmplitudesTimeWidget
-                spikeAmplitudesData={spikeAmplitudesData}
-                recording={recording}
-                sorting={sorting}
-                unitIds={selection.selectedUnitIds || []}
-                {...{width: 0, height: 0}} // filled in by splitter
-                selection={selection}
-                selectionDispatch={selectionDispatch}
-                curation={curation}
-            />
-        </Splitter>
-    )
+
+    return (!spikeAmplitudesData)
+        ? <div>Creating spike amplitudes data...</div>
+        : (
+            <Splitter
+                width={width || 600}
+                height={height || 900} // how to determine default height?
+                initialPosition={200}
+            >
+                <LockableSelectUnitsWidget
+                    sorting={sorting}
+                    selection={selectionLocal}
+                    selectionDispatch={selectionDispatchLocal}
+                    curation={curation}
+                    locked={locked}
+                    toggleLockStateCallback={() => setLocked(!locked)}
+                    sortingSelector={sortingSelector}
+                />
+                <SpikeAmplitudesTimeWidget
+                    spikeAmplitudesData={spikeAmplitudesData}
+                    recording={recording}
+                    sorting={sorting}
+                    unitIds={selectionLocal.selectedUnitIds || []}
+                    {...{width: 0, height: 0}} // filled in by splitter
+                    selection={selectionLocal}
+                    selectionDispatch={selectionDispatchLocal}
+                    curation={curation}
+                />
+            </Splitter>
+        )
 }
 
 export default SpikeAmplitudesView


### PR DESCRIPTION
Fixes #11 ([SortingView issue #136](https://github.com/magland/sortingview/issues/136)).

Pretty straightforward one here.

During the course of implementation, I noticed that the SpikeAmplitudesTimeWidget adds an empty panel if there are no units selected, in an attempt to make sure the y-axis is always displayed. However, that doesn't seem to be working. (I incidentally memoized it--despite the general preference not to have drive-by edits--but it looks like it wasn't working before, either.) We might need to look into this at some point.