### PR TITLE
Implement amplitude display and reset button. Incomplete implementati…

### DIFF
--- a/src/plugins/sortingview/ExperitimeTimeseriesPlugin/ExperitimeTimeWidget/ExperitimeTimeWidget.tsx
+++ b/src/plugins/sortingview/ExperitimeTimeseriesPlugin/ExperitimeTimeWidget/ExperitimeTimeWidget.tsx
@@ -1,7 +1,7 @@
 import CanvasWidget from 'figurl/labbox-react/components/CanvasWidget'
 import { CanvasPainter } from 'figurl/labbox-react/components/CanvasWidget/CanvasPainter'
 import { useLayer, useLayers } from 'figurl/labbox-react/components/CanvasWidget/CanvasWidgetLayer'
-import { ActionItem, DividerItem } from 'plugins/sortingview/gui/extensions/common/Toolbars'
+import { ActionItem, DividerItem, TextItem } from 'plugins/sortingview/gui/extensions/common/Toolbars'
 import React, { useCallback, useEffect, useState } from 'react'
 import { TimeseriesSelection, TimeseriesSelectionDispatch } from '../interface/TimeseriesSelection'
 import { createCursorLayer } from './cursorLayer'
@@ -12,7 +12,7 @@ import TimeSpanWidget, { SpanWidgetInfo } from './TimeSpanWidget'
 import TimeWidgetBottomBar from './TimeWidgetBottomBar'
 import TimeWidgetToolbarNew from './TimeWidgetToolbarNew'
 
-export type TimeWidgetAction = ActionItem | DividerItem
+export type TimeWidgetAction = ActionItem | DividerItem | TextItem
 
 interface Props {
     panels: TimeWidgetPanel[]

--- a/src/plugins/sortingview/gui/extensions/averagewaveforms/AverageWaveformsView/AverageWaveformsView.tsx
+++ b/src/plugins/sortingview/gui/extensions/averagewaveforms/AverageWaveformsView/AverageWaveformsView.tsx
@@ -5,16 +5,16 @@ import MarkdownDialog from 'figurl/labbox-react/components/Markdown/MarkdownDial
 import Splitter from 'figurl/labbox-react/components/Splitter/Splitter'
 import { useRecordingInfo } from 'plugins/sortingview/gui/pluginInterface/useRecordingInfo'
 import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
-import { FaArrowDown, FaArrowUp } from 'react-icons/fa'
+import { FaArrowDown, FaArrowUp, FaRegTimesCircle } from 'react-icons/fa'
 import SortingUnitPlotGrid from '../../../commonComponents/SortingUnitPlotGrid/SortingUnitPlotGrid'
 import info from '../../../helpPages/AverageWaveforms.md.gen'
 import { SortingViewProps } from '../../../pluginInterface'
-import { ActionItem, CheckboxItem, DividerItem } from '../../common/Toolbars'
+import { ActionItem, CheckboxItem, DividerItem, TextItem } from '../../common/Toolbars'
 import ViewToolbar from '../../common/ViewToolbar'
 import AverageWaveformView from './AverageWaveformView'
 
 
-export type AverageWaveformAction = ActionItem  | DividerItem | CheckboxItem
+export type AverageWaveformAction = ActionItem  | CheckboxItem | DividerItem | TextItem
 
 const TOOLBAR_INITIAL_WIDTH = 36 // hard-coded for now
 
@@ -59,6 +59,9 @@ const AverageWaveformsView: FunctionComponent<SortingViewProps> = (props) => {
     const _handleScaleAmplitudeDown = useCallback(() => {
         selectionDispatch({type: 'ScaleAmpScaleFactor', direction: 'down'})
     }, [selectionDispatch])
+    const _handleResetAmplitude = useCallback(() => {
+        selectionDispatch({type: 'SetAmpScaleFactor', ampScaleFactor: 1})
+    }, [selectionDispatch])
 
     useEffect(() => {
         const actions: AverageWaveformAction[] = [
@@ -71,10 +74,22 @@ const AverageWaveformsView: FunctionComponent<SortingViewProps> = (props) => {
             },
             {
                 type: 'button',
+                callback: _handleResetAmplitude,
+                title: 'Reset scale amplitude',
+                icon: <FaRegTimesCircle />
+            },
+            {
+                type: 'button',
                 callback: _handleScaleAmplitudeDown,
                 title: 'Scale amplitude down [down arrow]',
                 icon: <FaArrowDown />,
                 keyCode: 40
+            },
+            {
+                type: 'text',
+                title: 'Zoom level',
+                content: ampScaleFactor,
+                contentSigFigs: 2
             },
             {
                 type: 'divider'
@@ -87,7 +102,7 @@ const AverageWaveformsView: FunctionComponent<SortingViewProps> = (props) => {
             }
         ]
         setScalingActions(actions)
-    }, [_handleScaleAmplitudeUp, _handleScaleAmplitudeDown, _handleWaveformToggle, waveformsMode])
+    }, [_handleScaleAmplitudeUp, ampScaleFactor, _handleScaleAmplitudeDown, _handleResetAmplitude, _handleWaveformToggle, waveformsMode])
 
     const infoVisible = useVisible()
 

--- a/src/plugins/sortingview/gui/extensions/common/Toolbars.ts
+++ b/src/plugins/sortingview/gui/extensions/common/Toolbars.ts
@@ -13,6 +13,12 @@ export interface DividerItem {
     type: 'divider'
 }
 
+export interface TextItem {
+    type: 'text'
+    title: string
+    content: string | number
+    contentSigFigs?: number
+}
 export interface CheckboxItem {
     type: 'checkbox'
     callback: () => void

--- a/src/plugins/sortingview/gui/extensions/common/ViewToolbar.tsx
+++ b/src/plugins/sortingview/gui/extensions/common/ViewToolbar.tsx
@@ -16,6 +16,8 @@ type Button = {
     icon: any
     selected: boolean
     disabled?: boolean
+    content?: string | number
+    contentSigFigs?: number
     // TODO: Support for indeterminate state for checkboxes?
 }
 
@@ -34,7 +36,9 @@ const ViewToolbar: FunctionComponent<Props> = (props) => {
                 onClick: a.callback,
                 icon: a.icon || '',
                 selected: a.selected,
-                disabled: a.disabled
+                disabled: a.disabled,
+                content: a.content,
+                contentSigFigs: a.contentSigFigs
             });
         }
         return b
@@ -52,9 +56,31 @@ const ViewToolbar: FunctionComponent<Props> = (props) => {
                             </IconButton>
                         );
                     }
+                    else if (button.type === 'text') {
+                        const numericContent: number = Number.isFinite(button.content)
+                            ? button.content as any as number
+                            : 0
+                        const sigFigs = button.contentSigFigs || 0
+                        const roundsToInt = Math.abs(numericContent - Math.round(numericContent)) * (10**(sigFigs + 1)) < 1
+                        const _content = Number.isFinite(button.content)
+                            ? roundsToInt
+                                ? Math.round(numericContent) + ''
+                                : (numericContent).toFixed(button.contentSigFigs || 2)
+                            : (button.content || '')
+                        return (
+                            <div
+                                key={ii}
+                                title={button.title}
+                                style={{textAlign: 'center', fontWeight: 'bold'}}
+                            >
+                                {_content}
+                            </div>
+                        )
+                    }
                     else if (button.type === 'checkbox') {
                         return (
                             <Checkbox
+                                key={ii}
                                 checked={button.selected}
                                 onClick={button.onClick}
                                 style={{padding: 1, paddingLeft: 6 }}

--- a/src/plugins/sortingview/gui/extensions/common/sharedCanvasLayers/electrodesLayer.ts
+++ b/src/plugins/sortingview/gui/extensions/common/sharedCanvasLayers/electrodesLayer.ts
@@ -2,7 +2,7 @@ import { CanvasPainter } from "figurl/labbox-react/components/CanvasWidget/Canva
 import { CanvasDragEvent, CanvasWidgetLayer, ClickEvent, ClickEventType, DiscreteMouseEventHandler, DragHandler } from "figurl/labbox-react/components/CanvasWidget/CanvasWidgetLayer";
 import { pointIsInEllipse, RectangularRegion, rectangularRegionsIntersect } from "figurl/labbox-react/components/CanvasWidget/Geometry";
 import { RecordingSelectionDispatch } from '../../../pluginInterface';
-import { ActionItem, CheckboxItem, DividerItem } from "../Toolbars";
+import { ActionItem, CheckboxItem, DividerItem, TextItem } from "../Toolbars";
 import setupElectrodes, { ElectrodeBox } from './setupElectrodes';
 
 export type Electrode = {
@@ -34,7 +34,7 @@ export type ElectrodeLayerProps = {
     selectedElectrodeIds: number[]
     selectionDispatch: RecordingSelectionDispatch
     electrodeOpts: ElectrodeOpts
-    customActions?: (ActionItem | CheckboxItem | DividerItem )[]
+    customActions?: (ActionItem | CheckboxItem | DividerItem | TextItem )[]
 }
 
 type LayerState = {

--- a/src/plugins/sortingview/gui/extensions/timeseries/TimeWidgetNew/TimeWidgetNew.tsx
+++ b/src/plugins/sortingview/gui/extensions/timeseries/TimeWidgetNew/TimeWidgetNew.tsx
@@ -1,19 +1,19 @@
-import React, { useCallback, useEffect, useState } from 'react'
 import { CanvasPainter } from 'figurl/labbox-react/components/CanvasWidget/CanvasPainter'
 import CanvasWidget from 'figurl/labbox-react/components/CanvasWidget/CanvasWidget'
 import { useLayer, useLayers } from 'figurl/labbox-react/components/CanvasWidget/CanvasWidgetLayer'
+import React, { useCallback, useEffect, useState } from 'react'
 import { RecordingSelection, RecordingSelectionDispatch } from '../../../pluginInterface'
+import { ActionItem, DividerItem, TextItem } from '../../common/Toolbars'
 import { createCursorLayer } from './cursorLayer'
 import { createMainLayer } from './mainLayer'
+import { createMarkersLayer } from './markersLayer'
 import { createPanelLabelLayer } from './panelLabelLayer'
 import { createTimeAxisLayer } from './timeAxisLayer'
 import TimeSpanWidget, { SpanWidgetInfo } from './TimeSpanWidget'
 import TimeWidgetBottomBar from './TimeWidgetBottomBar'
 import TimeWidgetToolbarNew from './TimeWidgetToolbarNew'
-import { ActionItem, DividerItem } from '../../common/Toolbars'
-import { createMarkersLayer } from './markersLayer'
 
-export type TimeWidgetAction = ActionItem | DividerItem
+export type TimeWidgetAction = ActionItem | DividerItem | TextItem
 
 interface Props {
     panels: TimeWidgetPanel[]

--- a/src/plugins/sortingview/gui/extensions/timeseries/TimeseriesViewNew/TimeseriesWidgetNew.tsx
+++ b/src/plugins/sortingview/gui/extensions/timeseries/TimeseriesViewNew/TimeseriesWidgetNew.tsx
@@ -1,7 +1,7 @@
 import { useVisible } from 'figurl/labbox-react'
 import { CanvasPainter, PainterPath } from 'figurl/labbox-react/components/CanvasWidget/CanvasPainter'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { FaArrowDown, FaArrowUp, FaEye } from 'react-icons/fa'
+import { FaArrowDown, FaArrowUp, FaEye, FaRegTimesCircle } from 'react-icons/fa'
 import { RecordingSelection, RecordingSelectionDispatch, recordingSelectionReducer, SortingSelection } from '../../../pluginInterface'
 import useBufferedDispatch from '../../common/useBufferedDispatch'
 import { colorForUnitId } from '../../spikeamplitudes/SpikeAmplitudesView/SpikeAmplitudesPanel'
@@ -177,6 +177,10 @@ const TimeseriesWidgetNew = (props: Props) => {
     const _handleScaleAmplitudeDown = useCallback(() => {
         recordingSelectionDispatch({type: 'ScaleAmpScaleFactor', direction: 'down'})
     }, [recordingSelectionDispatch])
+    const _handleResetAmplitude = useCallback(() => {
+        recordingSelectionDispatch({type: 'SetAmpScaleFactor', ampScaleFactor: 1})
+    }, [recordingSelectionDispatch])
+
 
     const spikeMarkersVisibility = useVisible()
 
@@ -205,10 +209,22 @@ const TimeseriesWidgetNew = (props: Props) => {
             },
             {
                 type: 'button',
+                callback: _handleResetAmplitude,
+                title: 'Reset scale amplitude',
+                icon: <FaRegTimesCircle />
+            },
+            {
+                type: 'button',
                 callback: _handleScaleAmplitudeDown,
                 title: 'Scale amplitude down [down arrow]',
                 icon: <FaArrowDown />,
                 keyCode: 40
+            },
+            {
+                type: 'text',
+                title: 'Zoom level',
+                content: recordingSelection?.ampScaleFactor || 1,
+                contentSigFigs: 2
             },
             {
                 type: 'divider'
@@ -227,7 +243,7 @@ const TimeseriesWidgetNew = (props: Props) => {
             })
         }
         return a
-    }, [_handleScaleAmplitudeDown, _handleScaleAmplitudeUp, spikeAmplitudesData, spikeMarkersVisibility, sortingSelection])
+    }, [_handleScaleAmplitudeDown, recordingSelection.ampScaleFactor, _handleResetAmplitude, _handleScaleAmplitudeUp, spikeAmplitudesData, spikeMarkersVisibility, sortingSelection])
 
     const numTimepoints = useMemo(() => (timeseriesData ? timeseriesData.numTimepoints() : 0), [timeseriesData])
 


### PR DESCRIPTION
Fixes #10 ([SortingView issue #101](https://github.com/magland/sortingview/issues/101)).

This is partially a matter of taste, so we should take a look before merging, but I think it answers the brief. I've:

- Implemented a new text-display-type 'button' for the `ViewToolbar`. Text fields will display small text or numbers; if numeric content is detected, it will be automatically rounded to a specified number of decimal figures (and displayed as an integer if it is within that tolerance of an integral value).
- Used this feature to display the waveform amplitude scale level ('zoom level')
- Added a button w/ FontAwesome icon to reset the zoom level to 1
- Implemented these changes in the Average Waveforms view and the Timeseries view
- In the process, discovered that Timeseries is not using the same copy of the toolbar logic; made a ticket to correct that (As a result, the time series view doesn't display the numeric zoom level, it only has the reset button)
- Confirmed that everything still syncs up between the different views

NOTE that this PR is to merge into PR #9, which it builds off of. If they're both approved, this should be merged into the `7-waveform-geometry-view-control` branch first, so that that one will contain these changes when it is merged into main.